### PR TITLE
Improve JSX img log output

### DIFF
--- a/jsxProcessor.cjs
+++ b/jsxProcessor.cjs
@@ -31,14 +31,17 @@ fs.readFile(fullPath, "utf8", (err, data) => {
 
     if (/<img\b[^>]*>/.test(line) && !/alt\s*=/.test(line)) {
       const srcMatch = line.match(/src\s*=\s*{?"([^"}]+)"/);
-      const fallback = srcMatch?.[1]?.split("/").pop()?.split(".")[0] || "image";
+      const src = srcMatch?.[1] || "";
+      const fallback = src.split("/").pop()?.split(".")[0] || "image";
+
+      const imgTag = src ? `<img src="${src}">` : "<img>";
 
       if (mode === "fix") {
         line = line.replace(/<img\b/, `<img alt="${fallback}"`);
-        console.log(chalk.green(`✔️ Fixed alt="${fallback}" on <img>`));
+        console.log(chalk.green(`✔️ Fixed alt="${fallback}" on ${imgTag}`));
       } else {
         suggestionsToInsert.push(`// Suggestion: Add alt="${fallback}" to the image element below`);
-        console.log(chalk.blue(`💡 Suggest alt="${fallback}" for <img>`));
+        console.log(chalk.blue(`💡 Suggest alt="${fallback}" for ${imgTag}`));
       }
 
       suggestions++;


### PR DESCRIPTION
## Summary
- update `jsxProcessor.cjs` to capture the image `src` attribute
- include `<img src="...">` in fix and suggestion logs

## Testing
- `node index.cjs test-pages/test1.html fix | head -n 20`
- `node jsxProcessor.cjs test-pages/test2.jsx suggest >/tmp/out.txt && tail -n 3 /tmp/out.txt`


------
https://chatgpt.com/codex/tasks/task_e_685cf293e3288321907d1c024188846e